### PR TITLE
Fix DB.inc.php/Emoji support

### DIFF
--- a/include/DB.inc.php
+++ b/include/DB.inc.php
@@ -249,7 +249,7 @@ class Zotero_DB {
 			'username' => $info['user'],
 			'password' => $info['pass'],
 			'dbname'   => $info['db'],
-			'charset'  => !empty($info['charset']) ? $info['charset'] : 'utf8',
+			'charset'  => !empty($info['charset']) ? $info['charset'] : 'utf8mb4',
 			'driver_options' => [
 				"MYSQLI_OPT_CONNECT_TIMEOUT" => 5
 			]


### PR DESCRIPTION
If the note contains emoji emojis, then an error will be reported:.

Invalid character in note

Source line 1834 of `/var/www/zotero/model/Item.inc.php`

After confirming that the database encoding is set correctly, look for errors in Zotero_DB ::query(), after testing, it is determined that the encoding is set incorrectly in line 252 of `/var/www/zotero/include/DB.inc.php`, and the error is eliminated by changing `utf8` to `utf8mb4`.

Translated with DeepL.com (free version)